### PR TITLE
UA stack v1.4.354.23 (to get BouncyCastle v1.8.4)

### DIFF
--- a/app/Microsoft.Azure.IIoT.OpcUa.Services.Vault.App.csproj
+++ b/app/Microsoft.Azure.IIoT.OpcUa.Services.Vault.App.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.1985401" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.354.20-preview" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.354.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/module/Microsoft.Azure.IIoT.OpcUa.Modules.Vault.csproj
+++ b/module/Microsoft.Azure.IIoT.OpcUa.Modules.Vault.csproj
@@ -19,7 +19,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.354.20-preview" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.354.23" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Microsoft.Azure.IIoT.OpcUa.Services.Vault.csproj
+++ b/src/Microsoft.Azure.IIoT.OpcUa.Services.Vault.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.0" />
@@ -63,7 +63,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.354.20-preview" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.4.354.23" />
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -100,6 +100,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Content Update="appsettings.*.json" CopyToPublishDirectory="Never"/>
+    <Content Update="appsettings.*.json" CopyToPublishDirectory="Never" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation 

- Update OPC UA stack reference to latest released version, also bumping up the ref to bouncy castle version 1.8.4, which is now recommended for SDL.
